### PR TITLE
Update members-db-rust to v1.3.0

### DIFF
--- a/members-db-rust/docker-compose.yml
+++ b/members-db-rust/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   members-db-rust:
-    image: docker.pkg.github.com/approvers/members-db-rust/members-db-rust:1.2.0
+    image: docker.pkg.github.com/approvers/members-db-rust/members-db-rust:1.3.0
     container_name: members-db-rust
     ports:
       - 14001:8000


### PR DESCRIPTION
## Description
Updated members-db-rust to version 1.3.0.

## Affected Containers
- members-db-rust

## Checklist
- [x] Did you register your secret(s) to _Secrets_ section on _Settings_ tab?
- [x] Did you define your secret(s) to `.github/workflows/deployer.yml` ?
- [x] Did you add the directory you added to `.github/CODEOWNERS` ?
- [x] Did **NOT** you use hyphens in the name of the directory you created?
- [x] Did **NOT** you make any indents with tab character instead of spaces?
- [x] Did **NOT** you make any typo?
