### PR TITLE
Use unless-stopped restart policy

### DIFF
--- a/AHOXA/docker-compose.yml
+++ b/AHOXA/docker-compose.yml
@@ -4,5 +4,6 @@ services:
   ahoxa:
     image: docker.pkg.github.com/approvers/ahoxa/ahoxa:1.1.1
     container_name: ahoxa
+    restart: unless-stopped
     environment:
       - DISCORD_TOKEN=${AHOXA_DISCORD_TOKEN}

--- a/cadocr/docker-compose.yml
+++ b/cadocr/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   members-db-rust:
     image: docker.pkg.github.com/approvers/cadocr/cadocr:0.1.0
     container_name: cadocr
+    restart: unless-stopped
     entrypoint: /usr/local/bin/entrypoint
     environment:
       - Discord__Bot__Token=${CADOCR_DISCORD_BOT_TOKEN}

--- a/contacts_gateway/docker-compose.yml
+++ b/contacts_gateway/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   contacts_gateway:
     image: docker.pkg.github.com/approvers/contacts-gateway/contacts-gateway:0.1.0
     container_name: contacts_gateway
+    restart: unless-stopped
     environment: 
       - Twitter__ConsumerKey=${CONTACTS_GATEWAY_TWITTER_CONSUMER_KEY}
       - Twitter__ConsumerSecret=${CONTACTS_GATEWAY_TWITTER_CONSUMER_SECRET}

--- a/delitter/docker-compose.yml
+++ b/delitter/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   delitter:
     image: docker.pkg.github.com/approvers/delitter/delitter:1.0.0
     container_name: delitter
+    restart: unless-stopped
     environment:
       - DELITTER_DISCORD_SETTING_JSON_B64=${DELITTER_DISCORD_SETTING_JSON_B64}
       - DELITTER_TWITTER_SETTING_JSON_B64=${DELITTER_TWITTER_SETTING_JSON_B64}

--- a/dockerps-web/docker-compose.yml
+++ b/dockerps-web/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   dockerps_web:
     image: docker.pkg.github.com/approvers/dockerps-web/image:1.2.1
     container_name: dockerps_web
-    restart: always
+    restart: unless-stopped
     ports:
       - 8080:8080
     volumes:

--- a/genkai_dictionary/docker-compose.yml
+++ b/genkai_dictionary/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   genkai_dictionary:
     image: docker.pkg.github.com/approvers/genkai-dictionary/genkai-dictionary:1.0.0
     container_name: genkai_dictionary
+    restart: unless-stopped
     environment:
       - DISCORD_TOKEN=${GENKAI_DICTIONARY_DISCORD_TOKEN}
       - GENKAI_DICTIONARY_DISCORD_BOT_SETTING_JSON_B64=${GENKAI_DICTIONARY_DISCORD_BOT_SETTING_JSON_B64}

--- a/githubsecretary/docker-compose.yml
+++ b/githubsecretary/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   github_secretary:
     image: docker.pkg.github.com/approvers/github-secretary/github-secretary:1.3.0
     container_name: github_secretary
+    restart: unless-stopped
     environment:
       - DISCORD_TOKEN=${GITHUBSECRETARY_DISCORD_TOKEN}
       - FAUNA_SECRET=${GITHUBSECRETARY_FAUNA_SECRET}

--- a/imperial_police/docker-compose.yml
+++ b/imperial_police/docker-compose.yml
@@ -4,5 +4,6 @@ services:
   imperial-police:
     image: docker.pkg.github.com/approvers/imperial-police/imperial-police:1.0.0
     container_name: imperial-police
+    restart: unless-stopped
     environment:
       - IMPERIAL_POLICE_TOKEN=${IMPERIAL_POLICE_TOKEN}

--- a/kotoli/docker-compose.yml
+++ b/kotoli/docker-compose.yml
@@ -4,5 +4,6 @@ services:
   kotoli:
     image: docker.pkg.github.com/mirror-kt/kotoli/kotoli:1.0.0
     container_name: kotoli
+    restart: unless-stopped
     environment:
       - DISCORD_TOKEN=${KOTOLI_DISCORD_TOKEN}

--- a/members-db-rust/docker-compose.yml
+++ b/members-db-rust/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   members-db-rust:
     image: docker.pkg.github.com/approvers/members-db-rust/members-db-rust:1.3.0
     container_name: members-db-rust
+    restart: unless-stopped
     ports:
       - 14001:8000
 

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   nginx:
     image: nginx
     container_name: nginx
+    restart: unless-stopped
     network_mode: host
     environment:
       - TOKEN=${NGINX_EXAMPLE_TOKEN}

--- a/pindome_chan/docker-compose.yml
+++ b/pindome_chan/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   pindome-chan:
     image: docker.pkg.github.com/approvers/pindome-chan/pindome-chan:1.0
     container_name: pindome-chan
+    restart: unless-stopped
     environment:
       - DISCORD_TOKEN=${PINDOME_CHAN_DISCORD_TOKEN}
       - DISCORD_PERMISSIONS=${PINDOME_CHAN_DISCORD_PERMISSIONS}

--- a/vc_list_bot/docker-compose.yml
+++ b/vc_list_bot/docker-compose.yml
@@ -4,5 +4,6 @@ services:
   vc-list-bot:
     image: docker.pkg.github.com/approvers/vc-list-bot/vc-list-bot:1.0.1
     container_name: vc-list-bot
+    restart: unless-stopped
     environment:
       - DISCORD_BOT_TOKEN=${VC_LIST_BOT_DISCORD_TOKEN}


### PR DESCRIPTION
## Description
In case of upgrading or restarting the Docker daemon or the machine which is running the daemon, we need to restart containers manually after that.  It is not smart.  This pull request proposes to use `unless-stopped` restart policy among the containers.  The policy enforces the daemon to restart containers after launched, if the container is not stopped before exiting the previous session.

## Affected Containers
- AHOXA
- cadocr
- contacts_gateway
- delitter
- dockerps-web
- genkai_dictionary
- githubsecretary
- imperial_police
- kotoli
- members-db-rust
- nginx
- pindome_chan
- vc_list_bot

## Checklist
<!--
- [ ] Did you register your secret(s) to _Secrets_ section on _Settings_ tab?
- [ ] Did you define your secret(s) to `.github/workflows/deployer.yml` ?
- [ ] Did you add the directory you added to `.github/CODEOWNERS` ?
- [ ] Did **NOT** you use hyphens in the name of the directory you created?
-->
- [x] Did **NOT** you make any indents with tab character instead of spaces?
- [x] Did **NOT** you make any typo?
