### PR TITLE
Add "femalifing_com" container

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,4 @@
 /contacts_gateway/ @siketyan
 /delitter/ @loxygenK
 /imperial_police/ @Colk-tech
+/femalifing_com/ @loxygenK

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -9,11 +9,11 @@ ersion: '3'
 #       (maybe some people (like me) do)
 
 services:
-	femalifing_com:
-		image: docker.pkg.github.com/approvers/mesuochi.com/image:1.2.1
-		container_name: mesuochi_com
-		restart: unless-stopped
-		ports:
-			- 21001:8000
-		volumes:
-			- /var/run/docker.sock:/var/run/docker.sock:z
+  femalifing_com:
+    image: docker.pkg.github.com/approvers/mesuochi.com/image:1.2.1
+    container_name: mesuochi_com
+    restart: unless-stopped
+    ports:
+      - 21001:8000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:z

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+# note: the name of the domain which this container serves is "mesuochi.com",
+#       though the container's name is "femalifing_com".
+#       This name shake is for reducing the mental burden
+#       when typing this container's name, or looking this container's name, and so on.
+#
+#       yes don't forget that humans maybe dont like mesuochi
+#       (maybe some people (like me) do)
+
+services:
+  femalifing_com:
+    image: docker.pkg.github.com/approvers/femalifing_com/image:1.2.1
+    container_name: mesuochi_com
+    restart: unless-stopped
+    ports:
+      - 210001:8000
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:z

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -14,6 +14,6 @@ services:
     container_name: mesuochi_com
     restart: unless-stopped
     ports:
-      - 21001:8000
+      - 21001:80
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:z

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+ersion: '3'
 
 # note: the name of the domain which this container serves is "mesuochi.com",
 #       though the container's name is "femalifing_com".
@@ -9,11 +9,11 @@ version: '3'
 #       (maybe some people (like me) do)
 
 services:
-  femalifing_com:
-    image: docker.pkg.github.com/approvers/femalifing_com/image:1.2.1
-    container_name: mesuochi_com
-    restart: unless-stopped
-    ports:
-      - 210001:8000
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:z
+	femalifing_com:
+		image: docker.pkg.github.com/approvers/femalifing_com/image:1.2.1
+		container_name: mesuochi_com
+		restart: unless-stopped
+		ports:
+			- 21001:8000
+		volumes:
+			- /var/run/docker.sock:/var/run/docker.sock:z

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -14,4 +14,4 @@ services:
     container_name: femalifing_com
     restart: unless-stopped
     ports:
-      - 21001:80
+      - 14003:80

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -10,7 +10,7 @@ version: '3'
 
 services:
   femalifing_com:
-    image: docker.pkg.github.com/approvers/mesuochi.com/image:latest
+    image: docker.pkg.github.com/approvers/mesuochi.com/mesuochi.com:latest
     container_name: femalifing_com
     restart: unless-stopped
     ports:

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -10,7 +10,7 @@ ersion: '3'
 
 services:
 	femalifing_com:
-		image: docker.pkg.github.com/approvers/femalifing_com/image:1.2.1
+		image: docker.pkg.github.com/approvers/mesuochi.com/image:1.2.1
 		container_name: mesuochi_com
 		restart: unless-stopped
 		ports:

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -10,8 +10,8 @@ version: '3'
 
 services:
   femalifing_com:
-    image: docker.pkg.github.com/approvers/mesuochi.com/image:1.2.1
-    container_name: mesuochi_com
+    image: docker.pkg.github.com/approvers/mesuochi.com/image:latest
+    container_name: femalifing_com
     restart: unless-stopped
     ports:
       - 21001:80

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -15,5 +15,3 @@ services:
     restart: unless-stopped
     ports:
       - 21001:80
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:z

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -1,4 +1,4 @@
-ersion: '3'
+version: '3'
 
 # note: the name of the domain which this container serves is "mesuochi.com",
 #       though the container's name is "femalifing_com".

--- a/femalifing_com/docker-compose.yml
+++ b/femalifing_com/docker-compose.yml
@@ -10,7 +10,7 @@ version: '3'
 
 services:
   femalifing_com:
-    image: docker.pkg.github.com/approvers/mesuochi.com/mesuochi.com:latest
+    image: docker.pkg.github.com/approvers/mesuochi.com/mesuochi.com:0.1.2
     container_name: femalifing_com
     restart: unless-stopped
     ports:

--- a/nginx/conf/mesuochi.com.conf
+++ b/nginx/conf/mesuochi.com.conf
@@ -1,0 +1,10 @@
+server {
+    listen 443 ssl http2;
+    server_name mesuochi.com;
+    ssl_certificate /etc/certs/mesuochi.com/fullchain.pem;
+    ssl_certificate_key /etc/certs/mesuochi.com/privkey.pem;
+
+    location / {
+        proxy_pass http://127.0.0.1:21001;
+    }
+}

--- a/nginx/conf/mesuochi.com.conf
+++ b/nginx/conf/mesuochi.com.conf
@@ -5,6 +5,6 @@ server {
     ssl_certificate_key /etc/certs/mesuochi.com/privkey.pem;
 
     location / {
-        proxy_pass http://127.0.0.1:21001;
+        proxy_pass http://127.0.0.1:14003;
     }
 }


### PR DESCRIPTION
## Description
Add `femalifing_com` to serve `mesuochi.com` website.
\* I keep this pull request as a "draft" until the migration of "mesuochi.com" to the container is complete.

### About the name shaking
I noticed that some people doesn't like 'メス堕ち'(mesuochi), and maybe they hate it,
so I decided to reduce the usage of the word 'メス堕ち'(mesuochi).
(the same thing is written in `dokcer-compose.yml`)

## Affected Containers
- `femalifing_com`

## Checklist
- [X] ~~Did you register your secret(s) to _Secrets_ section on _Settings_ tab?~~ *No secrets for `femalifing_com`*
- [X] ~~Did you define your secret(s) to `.github/workflows/deployer.yml` ?~~ *No secrets for `femalifing_com`*
- [X] Did you add the directory you added to `.github/CODEOWNERS` ?
- [X] Did **NOT** you use hyphens in the name of the directory you created?
- [X] Did **NOT** you make any indents with tab character instead of spaces?
- [X] Did **NOT** you make any typo?
