### PR TITLE
🔧 Fix the path of Let's Encrypt certs for nginx

### DIFF
--- a/nginx/conf/default.conf
+++ b/nginx/conf/default.conf
@@ -1,8 +1,8 @@
 server {
     listen 443 ssl http2;
     server_name containers.siketyan.approvers.dev;
-    ssl_certificate /etc/certs/containers.siketyan.approvers.dev/fullchain.pem;
-    ssl_certificate_key /etc/certs/containers.siketyan.approvers.dev/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/containers.siketyan.approvers.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/containers.siketyan.approvers.dev/privkey.pem;
 
     location / {
         proxy_pass http://127.0.0.1:8080;
@@ -12,8 +12,8 @@ server {
 server {
     listen 443 ssl http2;
     server_name containers.approvers.dev;
-    ssl_certificate /etc/certs/containers.approvers.dev/fullchain.pem;
-    ssl_certificate_key /etc/certs/containers.approvers.dev/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/containers.approvers.dev/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/containers.approvers.dev/privkey.pem;
 
     location / {
         proxy_pass http://127.0.0.1:8080;

--- a/nginx/conf/mesuochi.com.conf
+++ b/nginx/conf/mesuochi.com.conf
@@ -1,8 +1,8 @@
 server {
     listen 443 ssl http2;
     server_name mesuochi.com;
-    ssl_certificate /etc/certs/mesuochi.com/fullchain.pem;
-    ssl_certificate_key /etc/certs/mesuochi.com/privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/mesuochi.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mesuochi.com/privkey.pem;
 
     location / {
         proxy_pass http://127.0.0.1:14003;

--- a/nginx/docker-compose.yml
+++ b/nginx/docker-compose.yml
@@ -12,6 +12,6 @@ services:
       - 80:80
       - 443:443
     volumes:
-      - /etc/certs:/etc/certs:z
+      - /etc/letsencrypt:/etc/letsencrypt:z
       - ./conf:/etc/nginx/conf.d:z
       - ./html:/var/www/html:z


### PR DESCRIPTION
## Description
Formerly, `/etc/certs` was a normal directory, containing certificates for nginx container.
Now that directory is a symlink to `/etc/letsencrypt`, then we need to add binding of `/etc/letsencrypt` by Docker volumes.
However, the symlink is no longer needed, I decided to change the binding from `/etc/certs` to `/etc/letsencrypt`, editing all of ceritifacte paths in the current nginx configuration.
Note that binding only `/etc/letsencrypt/live` is not correct 'cause it's a collection of symlinks to the actual certificate files.

## Affected Containers
- nginx

## Checklist
<!--
- [ ] Did you register your secret(s) to _Secrets_ section on _Settings_ tab?
- [ ] Did you define your secret(s) to `.github/workflows/deployer.yml` ?
- [ ] Did you add the directory you added to `.github/CODEOWNERS` ?
- [ ] Did you make all indents with spaces instead of tab character?
- [ ] Did **NOT** you use hyphens in the name of the directory you created?
-->
- [x] Did **NOT** you make any typo?
