### PR TITLE
GitHub Secretary の更新

### DIFF
--- a/githubsecretary/docker-compose.yml
+++ b/githubsecretary/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   github_secretary:
-    image: ghcr.io/approvers/github-secretary:1.4.0
+    image: ghcr.io/approvers/github-secretary:v1.5.1
     container_name: github_secretary
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Description
GitHub Secretary のバージョン更新です. [変更内容はこちら](https://github.com/approvers/github-secretary/releases/tag/v1.5.0).

リリース CI に手間取った関係でバージョン番号は v1.5.1 になっています.

## Affected Containers
- github_secretary

## Checklist
- [x] Did you register your secret(s) to _Secrets_ section on _Settings_ tab?
- [x] Did you define your secret(s) to `.github/workflows/deployer.yml` ?
- [x] Did you add the directory you added to `.github/CODEOWNERS` ?
- [x] Did you make all indents with spaces instead of tab character?
- [x] Did **NOT** you use hyphens in the name of the directory you created?
- [x] Did **NOT** you make any typo?
